### PR TITLE
Feat: HTTP exception filter를 구현합니다.

### DIFF
--- a/src/common/filters/HttpExceptionFilter.filter.ts
+++ b/src/common/filters/HttpExceptionFilter.filter.ts
@@ -1,0 +1,34 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: Error, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse<Response>();
+    const req = ctx.getRequest<Request>();
+
+    if (!(exception instanceof HttpException)) {
+      exception = new InternalServerErrorException();
+    }
+
+    const response: any = (exception as HttpException).getResponse();
+
+    const log = {
+      timestamp: new Date(),
+      url: req.url,
+      response,
+    };
+
+    Logger.log(log);
+
+    res.status((exception as HttpException).getStatus()).json(response);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { HttpExceptionFilter } from './common/filters/HttpExceptionFilter.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -9,6 +10,8 @@ async function bootstrap() {
     origin: process.env.ALLOWED_ORIGINS,
     credentials: true,
   });
+
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->

close #8 

## ☑️ 완료 태스크

- [x] HTTP exception filter 구현

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

HTTP 예외처리를 위한 전역 filter를 구현했어요.

`@Catch()` 데코레이터로 처리되지 않은 모든 예외를 캐치하고, HttpException이 아닌 에러는 500 Internal Server Error로 변환해요.

추가적으로 Timestamp, Request URL, Response를 로깅하도록 했어요.

